### PR TITLE
Modify the order of BN and Conv of RepMixer

### DIFF
--- a/models/fastvit.py
+++ b/models/fastvit.py
@@ -282,6 +282,7 @@ class RepMixer(nn.Module):
                 padding=kernel_size // 2,
                 groups=dim,
                 use_act=False,
+                use_bn_conv=True,
             )
             self.use_layer_scale = use_layer_scale
             if use_layer_scale:


### PR DESCRIPTION
[FastViT paper](https://arxiv.org/pdf/2303.14189.pdf) has the **BN -> Conv** order in the Repmixer block. But in this repo, it is in the **reverse order.** Included a flag 'use_bn_conv' to achieve this order, only for the RepMixer Block. I attached the screenshots of the model before and after the change. 

**RepMixer_block_FastViT_code**
<img src="https://github.com/apple/ml-fastvit/assets/27886970/2b43c0a2-0d99-4372-8a65-56a2b4efa552" width="200" height="200" />
**Corrected_RepMixer_block**
<img src="https://github.com/apple/ml-fastvit/assets/27886970/041c47b7-5c3d-4b78-9182-c8892e4f4297" width="200" height="200" />

@anuragranj @pavank-apple please have a look at this change.

